### PR TITLE
Migrate profile data and define properties

### DIFF
--- a/migrations/20251015_01_create_property_definitions.sql
+++ b/migrations/20251015_01_create_property_definitions.sql
@@ -1,0 +1,40 @@
+-- Create property_definitions table
+-- Up
+CREATE TABLE IF NOT EXISTS property_definitions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL,
+  key TEXT NOT NULL,
+  data_type TEXT NOT NULL CHECK (data_type IN ('text', 'number', 'boolean', 'datetime')),
+  description TEXT,
+  property_type TEXT NOT NULL CHECK (property_type IN ('default', 'custom')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ,
+  CONSTRAINT property_definitions_workspace_key_unique UNIQUE (workspace_id, key)
+);
+
+-- Trigger to update updated_at
+CREATE OR REPLACE FUNCTION set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+  CREATE TRIGGER set_property_definitions_updated_at
+  BEFORE UPDATE ON property_definitions
+  FOR EACH ROW
+  EXECUTE PROCEDURE set_timestamp();
+EXCEPTION WHEN duplicate_object THEN
+  -- trigger already exists
+  NULL;
+END $$;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_property_definitions_workspace_id ON property_definitions(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_property_definitions_key ON property_definitions(key);
+
+-- Down
+-- DROP TABLE IF EXISTS property_definitions;

--- a/migrations/20251015_02_seed_default_property_definitions.sql
+++ b/migrations/20251015_02_seed_default_property_definitions.sql
@@ -1,0 +1,25 @@
+-- Seed default property definitions for existing workspaces
+-- Assumptions:
+-- - There is a workspaces table with id
+-- - Default properties come from profiles columns: name, email, address fields, created_at
+
+WITH defaults AS (
+  SELECT * FROM (
+    VALUES
+      ('email',        'text',     'Primary email address',               'default'),
+      ('name',         'text',     'Full name',                           'default'),
+      ('phoneNumber',  'text',     'Phone number',                        'default'),
+      ('birthdate',    'datetime', 'Birthdate',                           'default'),
+      ('country',      'text',     'Country',                             'default'),
+      ('city',         'text',     'City',                                'default'),
+      ('street',       'text',     'Street address',                      'default'),
+      ('stateProvince','text',     'State or province',                   'default'),
+      ('postalCode',   'text',     'Postal or ZIP code',                  'default'),
+      ('createdAt',    'datetime', 'Profile created timestamp',           'default')
+  ) AS t(key, data_type, description, property_type)
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT w.id, d.key, d.data_type, d.description, d.property_type
+FROM workspaces w
+CROSS JOIN defaults d
+ON CONFLICT (workspace_id, key) DO NOTHING;

--- a/migrations/20251015_03_down_property_definitions.sql
+++ b/migrations/20251015_03_down_property_definitions.sql
@@ -1,0 +1,16 @@
+-- Rollback for property_definitions and seeded data
+-- This will drop the table and associated trigger/function
+
+DO $$ BEGIN
+  DROP TRIGGER IF EXISTS set_property_definitions_updated_at ON property_definitions;
+EXCEPTION WHEN undefined_table THEN
+  NULL;
+END $$;
+
+DO $$ BEGIN
+  DROP FUNCTION IF EXISTS set_timestamp();
+EXCEPTION WHEN undefined_function THEN
+  NULL;
+END $$;
+
+DROP TABLE IF EXISTS property_definitions;


### PR DESCRIPTION
Add `property_definitions` table and seed it with default profile properties to generalize property management.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a79411c-3316-4949-866e-57dd0577f075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a79411c-3316-4949-866e-57dd0577f075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

