### PR TITLE
Migrate profile data and define properties

### DIFF
--- a/migrations/20251015_0001_create_property_definitions.sql
+++ b/migrations/20251015_0001_create_property_definitions.sql
@@ -1,0 +1,43 @@
+-- Create property_definitions table and related objects
+-- Safe to run once in a fresh migration chain
+
+-- Ensure required extensions exist
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Create table
+CREATE TABLE IF NOT EXISTS property_definitions (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id  UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  key           TEXT NOT NULL,
+  data_type     TEXT NOT NULL CHECK (data_type IN ('text','number','boolean','datetime')),
+  description   TEXT,
+  property_type TEXT NOT NULL CHECK (property_type IN ('default','custom')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at    TIMESTAMPTZ
+);
+
+-- Enforce uniqueness of active (non-deleted) keys per workspace via partial unique index
+CREATE UNIQUE INDEX IF NOT EXISTS property_definitions_workspace_key_unique
+  ON property_definitions(workspace_id, key)
+  WHERE deleted_at IS NULL;
+
+-- Helpful supporting indexes
+CREATE INDEX IF NOT EXISTS property_definitions_workspace_idx
+  ON property_definitions(workspace_id);
+
+-- Generic trigger function to auto-update updated_at on row updates
+CREATE OR REPLACE FUNCTION set_updated_at_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate trigger idempotently
+DROP TRIGGER IF EXISTS trg_property_definitions_set_updated_at ON property_definitions;
+CREATE TRIGGER trg_property_definitions_set_updated_at
+BEFORE UPDATE ON property_definitions
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();

--- a/migrations/20251015_0002_seed_default_profile_properties.sql
+++ b/migrations/20251015_0002_seed_default_profile_properties.sql
@@ -1,0 +1,83 @@
+-- Seed default property definitions derived from existing profiles columns
+-- Assumptions:
+-- - There is a profiles table with a workspace_id column
+-- - There is a workspaces table referenced by property_definitions.workspace_id
+-- - Default property keys and types are as follows
+--     email (text), phoneNumber (text), birthdate (datetime), name (text),
+--     country (text), city (text), street (text), stateProvince (text), postalCode (text),
+--     createdAt (datetime)
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (
+  workspace_id, key, data_type, description, property_type
+)
+-- email
+SELECT workspace_id, 'email', 'text', 'Email address', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'phoneNumber', 'text', 'Phone number', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'birthdate', 'datetime', 'Birthdate', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'name', 'text', 'Full name', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+-- Address fields
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'country', 'text', 'Country', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'city', 'text', 'City', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'street', 'text', 'Street address', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'stateProvince', 'text', 'State or province', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'postalCode', 'text', 'Postal code', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;
+
+-- createdAt timestamp
+WITH distinct_workspaces AS (
+  SELECT DISTINCT workspace_id FROM profiles
+)
+INSERT INTO property_definitions (workspace_id, key, data_type, description, property_type)
+SELECT workspace_id, 'createdAt', 'datetime', 'Profile creation timestamp', 'default' FROM distinct_workspaces
+ON CONFLICT (workspace_id, key) WHERE property_definitions.deleted_at IS NULL DO NOTHING;


### PR DESCRIPTION
Add `property_definitions` table and seed default profile properties to generalize property management.

---
<a href="https://cursor.com/background-agent?bcId=bc-8efff445-2afd-4606-8587-7469cefa2172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8efff445-2afd-4606-8587-7469cefa2172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

